### PR TITLE
Improve response logging and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ good-bunyan
 Creates a new GoodBunyan object with the following arguments:
 
 - `events` - an object of key value pairs.
-	- `key` - one of the supported [good events](https://github.com/hapijs/good) indicating the hapi event to subscribe to
-	- `value` - a single string or an array of strings to filter incoming events. "\*" indicates no filtering. `null` and `undefined` are assumed to be "\*"
+  - `key` - one of the supported [good events](https://github.com/hapijs/good) indicating the hapi event to subscribe to
+  - `value` - a single string or an array of strings to filter incoming events. "\*" indicates no filtering. `null` and `undefined` are assumed to be "\*"
 - `config` - configuration object with the following available keys
-	- `logger` (required) - [bunyan](https://github.com/trentm/node-bunyan/) logger instance.
+  - `logger` (required) - [bunyan](https://github.com/trentm/node-bunyan/) logger instance.
   - `levels` - object used to override the bunyan levels of each good event type. Each key is a [good event](https://github.com/hapijs/good) (`ops`, `repsonse`, `log`, `error` and `request`), and the values must be a [bunyan level](https://github.com/trentm/node-bunyan#levels) (`trace`, `debug`, `info`, `error` or `fatal`).
   - `formatters` - object used to override the message passed to buyan. Each key is a [good event](https://github.com/hapijs/good) (`ops`, `repsonse`, `log`, `error` and `request`), and the values must be functions which take an object `data` as the argument and output, either a `string`, or an array of arguments to be passed for the bunyan log.
 
@@ -43,6 +43,7 @@ server.connection({ host: 'localhost' });
 
 var options = {
   opsInterval: 1000,
+  responsePayload: true, // enable this to log response payloads
   reporters: [{
     reporter: require('good-bunyan'),
     config: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var Squeeze = require('good-squeeze').Squeeze;
 var Through = require('through2');
 var bunyan = require('bunyan');
 var Joi = require('joi');
+var util = require('./util');
 
 var availableLevels = Object.keys(bunyan.levelFromName);
 
@@ -14,21 +15,23 @@ var defaultFormatters = {
     }, '[ops]'];
   },
   response: function (data) {
-    var query = data.query ? JSON.stringify(data.query) : '';
-    var responsePayload = '';
-    if (typeof data.responsePayload === 'object' && data.responsePayload) {
-      responsePayload = 'response payload: ' + JSON.stringify(data.responsePayload);
+    var payload = {};
+
+    if (util.isObject(data.responsePayload) || util.isArray(data.responsePayload)) {
+      payload.responsePayload = JSON.stringify(data.responsePayload);
     }
 
-    return [{
-      instance: data.instance,
-      method: data.method,
-      path: data.path,
-      query: query,
-      statusCode: data.statusCode,
-      responseTime: data.responseTime + 'ms',
-      responsePayload: responsePayload
-    }, '[response]'];
+    if (!util.isEmptyObject(data.query)) {
+      payload.query = JSON.stringify(data.query);
+    }
+
+    payload.instance = data.instance;
+    payload.method = data.method;
+    payload.path = data.path;
+    payload.statusCode = data.statusCode;
+    payload.responseTime = data.responseTime + 'ms';
+
+    return [payload, '[response]'];
   },
   error: function (data) {
     return [{

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function isArray (x) {
+  return Object.prototype.toString.call(x) === '[object Array]';
+}
+
+function isObject (x) {
+  return Object.prototype.toString.call(x) === '[object Object]';
+}
+
+function isEmptyObject (x) {
+  return isObject(x) && Object.keys(x).length === 0;
+}
+
+module.exports = {
+  isArray: isArray,
+  isEmptyObject: isEmptyObject,
+  isObject: isObject
+};
+


### PR DESCRIPTION
In order to save space in the printed logs, I added conditional logging
of `query` and `responsePayload`. I also added an example to the README
showing how to log response payloads.

I added the `util.js` file so we didn't need to pull in another
dependency like lodash.