### PR TITLE
Fix logger validation problem and add the ability to override the default level with tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Creates a new GoodBunyan object with the following arguments:
   - `value` - a single string or an array of strings to filter incoming events. "\*" indicates no filtering. `null` and `undefined` are assumed to be "\*"
 - `config` - configuration object with the following available keys
   - `logger` (required) - [bunyan](https://github.com/trentm/node-bunyan/) logger instance.
-  - `levels` - object used to override the bunyan levels of each good event type. Each key is a [good event](https://github.com/hapijs/good) (`ops`, `repsonse`, `log`, `error` and `request`), and the values must be a [bunyan level](https://github.com/trentm/node-bunyan#levels) (`trace`, `debug`, `info`, `error` or `fatal`).
+  - `levels` - object used to set the default bunyan level for each good event type. Each key is a [good event](https://github.com/hapijs/good) (`ops`, `repsonse`, `log`, `error` and `request`), and the values must be a [bunyan level](https://github.com/trentm/node-bunyan#levels) (`trace`, `debug`, `info`, `error` or `fatal`). Please note that `good-bunyan` will first try to look for a valid bunyan level within the event tags (e.g. using the tag ['error', 'handler'] will result in using the bunyan 'error' level).
   - `formatters` - object used to override the message passed to buyan. Each key is a [good event](https://github.com/hapijs/good) (`ops`, `repsonse`, `log`, `error` and `request`), and the values must be functions which take an object `data` as the argument and output, either a `string`, or an array of arguments to be passed for the bunyan log.
 
 ## Good Bunyan Methods

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ var settingsSchema = Joi.object().keys({
     error: Joi.func().default(defaultFormatters.error),
     request: Joi.func().default(defaultFormatters.request)
   }),
-  logger: Joi.object().type(bunyan).required()
+  logger: Joi.object().required()
 });
 
 var GoodBunyan = function GoodBunyan (events, config) {
@@ -86,6 +86,28 @@ var GoodBunyan = function GoodBunyan (events, config) {
   this._filter = new Squeeze(events);
 };
 
+
+GoodBunyan.prototype._getLevel = function(eventName, tags) {
+  if(Array.isArray(tags)) {
+    if (tags.indexOf('fatal') !== -1) {
+      return 'fatal';
+    } else if (tags.indexOf('error') !== -1) {
+      return 'error';
+    } else if (tags.indexOf('warn') !== -1) {
+      return 'warn';
+    } else if (tags.indexOf('info') !== -1) {
+      return 'info';
+    } else if (tags.indexOf('debug') !== -1) {
+      return 'debug';
+    } else if (tags.indexOf('trace') !== -1) {
+      return 'trace';
+    }
+  }
+  
+  //return default level
+  return this.settings.levels[eventName];
+}
+
 GoodBunyan.prototype.init = function (stream, emitter, callback) {
   var self = this;
 
@@ -95,9 +117,9 @@ GoodBunyan.prototype.init = function (stream, emitter, callback) {
 
   stream.pipe(this._filter).pipe(Through.obj(function goodBunyanTransform (data, enc, next) {
     var eventName = data.event;
-
-    if (self.settings.levels[eventName]) {
-      var level = self.settings.levels[eventName];
+  
+    var level = self._getLevel(eventName, data.tags)
+    if (level) {
       var formatted = self.settings.formatters[eventName](data);
 
       if (formatted instanceof Array) {


### PR DESCRIPTION
This PR addresses 2 issues: 

1. We can't check that logger is an instance of the bunyan logger since the logger passed from the application might be created from another instance of the bunyan dependency (e.g. different version from the one used by good-bunyan)
2. Allow the user to override the default logging levels using tags (e.g. ['error', 'handler'] resolves to the 'error' level in bunyan.