### PR TITLE
Remove unnecessary pipe to stdout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ GoodBunyan.prototype._getLevel = function(eventName, tags) {
       return 'trace';
     }
   }
-  
+
   //return default level
   return this.settings.levels[eventName];
 }
@@ -117,7 +117,7 @@ GoodBunyan.prototype.init = function (stream, emitter, callback) {
 
   stream.pipe(this._filter).pipe(Through.obj(function goodBunyanTransform (data, enc, next) {
     var eventName = data.event;
-  
+
     var level = self._getLevel(eventName, data.tags)
     if (level) {
       var formatted = self.settings.formatters[eventName](data);
@@ -134,7 +134,7 @@ GoodBunyan.prototype.init = function (stream, emitter, callback) {
     self.logger.trace(data, '[' + eventName + '] (unknown event)');
 
     return next();
-  })).pipe(process.stdout);
+  }));
 
   callback();
 };


### PR DESCRIPTION
Piping the stream to stdout appears to be redundant. It is causing us some problems with too many event listeners being registered during our tests, where the plugin is initialised multiple times within the same process.