### PR TITLE
Allow to pass object with custom msg to log events

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ server.register(
 
 ```
 
+### Example with custom msg
+```javascript
+server.log('info', { msg: 'Server started', uri: server.info.uri }; 
+```
+
 ## Compatibility
 
 `good-bunyan` complies with the `good 7.x.x` [API](https://github.com/hapijs/good/blob/master/API.md).

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,11 @@ class GoodBunyan extends Stream.Transform {
     const formatted = this.settings.formatters[eventName](data);
     const args = Array.isArray(formatted) ? formatted : [formatted];
 
+    if (typeof formatted[0] === 'object' && formatted[0].msg) {
+      formatted[formatted.length - 1] = `${formatted[formatted.length - 1]} ${formatted[0].msg}`;
+      delete formatted[0].msg;
+    }
+
     this.logger[level].apply(this.logger, args);
 
     return next(null);


### PR DESCRIPTION
This PR allows to pass custom messages to log events, for example:

```javascript
server.log('info', { msg: 'Server started', uri: server.info.uri };
```

Will result in:
```
{
  // ... default bunyan data
  "msg":"[log] Server started",
  "uri":"http://localhost:3000"
}
```

![bunyan cli](https://cloud.githubusercontent.com/assets/6516539/20260262/c049c066-aa50-11e6-9085-25fd54aaebd2.png)


I've also added 3 tests. One for default log events as a string, one with data object and another one with data object and a custom `msg`.