### PR TITLE
Update fast-safe-stringify to 1.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/muzzley/good-bunyan",
   "dependencies": {
     "bunyan": "1.8.x",
-    "fast-safe-stringify": "1.0.9",
+    "fast-safe-stringify": "1.1.3",
     "good-squeeze": "4.0.x",
     "hoek": "4.0.x",
     "joi": "9.0.x"


### PR DESCRIPTION
Updating `fast-safe-stringify` to `v1.1.x` due to [deprecation warning](https://github.com/davidmarkclements/fast-safe-stringify/issues/4#issuecomment-246638427):
```
npm WARN deprecated fast-safe-stringify@1.0.9: use 1.1.0+ see https://github.com/davidmarkclements/fast-safe-stringify/issues/4
```