### PR TITLE
try and catch formatter errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,15 @@ class GoodBunyan extends Stream.Writable {
       return next(null);
     }
 
-    const formatted = this.settings.formatters[eventName](data);
+    let formatted;
+
+    try {
+        formatted = this.settings.formatters[eventName](data);
+    } catch (e) {
+        console.error(e);
+        return next(null);
+    }
+
     const args = Array.isArray(formatted) ? formatted : [formatted];
 
     if (typeof formatted[0] === 'object' && formatted[0].msg) {


### PR DESCRIPTION
I've been debugging a weird production bug where hapi would stop emitting `response` events while still serving requests and everything else working just fine. I've pinpointed this to `good-bunyan` and my custom `response` formatter that would throw an error in edge case scenarios, breaking any next `response` events from being triggered.

You can replicate with:

```javascript
formatters: {
    response: function (payload) {
        throw new Error();
    }
}
```

Any `response` events after 1st attempt are not emitted anywhere (including throwing the same error again), which also breaks other plugins that listen to the `response` events.

This PR wraps the formatters inside a `try...catch` and returns `null` if there's an error, as well as `console.error()`'ing the error, which stops breaking any next hapi `response` events.

Should we handle formatter errors differently? I've tried returning the `error` instead of `null`, but then `good` breaks next `response` events as well and complains (from [monitor.js:129](https://github.com/hapijs/good/blob/45606c7df27767f29314d207a8fb66c72f90cc1a/lib/monitor.js#L129))

>There was a problem (Error) in bunyan and it has been destroyed.