### PR TITLE
Update dependencies to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
   "homepage": "https://github.com/muzzley/good-bunyan",
   "dependencies": {
     "bunyan": "1.8.x",
-    "fast-safe-stringify": "1.1.3",
-    "good-squeeze": "4.0.x",
-    "hoek": "4.0.x",
-    "joi": "9.0.x"
+    "fast-safe-stringify": "1.1.x",
+    "good-squeeze": "5.0.x",
+    "hoek": "4.1.x",
+    "joi": "10.4.x"
   },
   "devDependencies": {
-    "code": "3.0.2",
-    "hoek": "4.0.2",
-    "lab": "10.9.0",
-    "semistandard": "8.0.0"
+    "code": "4.0.0",
+    "hoek": "4.1.1",
+    "lab": "13.0.4",
+    "semistandard": "11.0.0"
   },
   "peerDependencies": {
     "good": "7.x"


### PR DESCRIPTION
Updating dependencies to the latest version due to following deprecation warnings:

1. `npm WARN deprecated fast-safe-stringify@1.0.9: use 1.1.0+ see https://github.com/davidmarkclements/fast-safe-stringify/issues/4`

2. `npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`