### PR TITLE
Marked good v8 as a valid peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "semistandard": "^12.0.0"
   },
   "peerDependencies": {
-    "good": "7.x"
+    "good": "7.x || 8.x"
   }
 }


### PR DESCRIPTION
seems to work fine with good v8, so this removes the peer dependency warning (and lets `npm ls` exit with `0`)